### PR TITLE
Fix critical error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flutterflow-custom-code-editor",
   "displayName": "FlutterFlow: Custom Code Editor",
   "description": "Edit your FlutterFlow custom  widgets, action, and functions.",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "publisher": "FlutterFlow",
   "repository": {
 		"type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -198,7 +198,6 @@ export function activate(context: vscode.ExtensionContext): vscode.ExtensionCont
         const apiClient = new FlutterFlowApiClient(getApiKey(), getCurrentApiUrl(), projectId, branchName);
         const syncCodeResult = await pushToFF(apiClient, projectRoot, currentUpdateManager, requestId);
 
-        vscode.window.showInformationMessage("Push to FlutterFlow completed.");
 
         // Handle sync results
         if (syncCodeResult.error) {
@@ -209,6 +208,9 @@ export function activate(context: vscode.ExtensionContext): vscode.ExtensionCont
         if (!hasCriticalErrors) {
           await currentUpdateManager.setToSynced();
           modifiedFileTreeProvider.clearAllFiles();
+          vscode.window.showInformationMessage("Push to FlutterFlow completed.");
+        } else {
+          vscode.window.showErrorMessage("Push to FlutterFlow failed. View FlutterFlow warnings panel for details.");
         }
       });
     }


### PR DESCRIPTION
Properly show an error when push to flutterflow fails. Previou7sly if we encountered a critical error the ui still indicated success.
<img width="1755" alt="Screenshot 2025-01-27 at 10 45 50 AM" src="https://github.com/user-attachments/assets/806a69fa-651b-4bf1-a521-7bcd08b6c0a0" />
