### PR TITLE
Allow opening custom code from Vscode:// links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.2.0
+
+- Removed requirement to run "Start Code Editing Session" command. Environment initialization (Flutter setup and package installation) now happens automatically after downloading code.
+
 ## 1.1.9
 
 - Fix issue with downloading assets on Windows.

--- a/README.md
+++ b/README.md
@@ -28,17 +28,11 @@ This command will prompt you for three pieces of information:
 
 3. **Download Location**: A file picker will be presented for you to choose where to download your project code. The code will be downloaded to `<selected_directory>/<projectID>`.
 
-### Initialize a Code Editing Session
-
-After the code has been downloaded, you will need to initiate a **Code Editing** session using the extension. When a Code Editing session has been initiated, you’ll be able to pull and push code from VSCode to FlutterFlow.
-
-To start a Code Editing session, run the command `FlutterFlow: Start Code Editing Session`. 
-
-This command will also automatically run `flutter pub get` and will attempt to install the version of the flutter SDK currently used by FlutterFlow.
+After downloading, the extension will automatically begin initializing your environment. This process includes setting up the correct Flutter version and running `flutter pub get`, which may take a few seconds. Once initialization is complete, you can begin editing your code.
 
 ### Editing Custom Code
 
-Once your session has been initialized, you can begin adding or editing custom code. 
+Once initialization is complete, you can begin adding or editing custom code. 
 
 Right now, the only files that are editable are:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flutterflow-custom-code-editor",
   "displayName": "FlutterFlow: Custom Code Editor",
   "description": "Edit your FlutterFlow custom  widgets, action, and functions.",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "publisher": "FlutterFlow",
   "repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flutterflow-custom-code-editor",
   "displayName": "FlutterFlow: Custom Code Editor",
   "description": "Edit your FlutterFlow custom  widgets, action, and functions.",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "publisher": "FlutterFlow",
   "repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flutterflow-custom-code-editor",
   "displayName": "FlutterFlow: Custom Code Editor",
   "description": "Edit your FlutterFlow custom  widgets, action, and functions.",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "publisher": "FlutterFlow",
   "repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
         "command": "flutterflow.handleUri",
         "title": "Handle FlutterFlow URI"
       }
-
     ],
     "configuration": {
       "title": "FlutterFlow",
@@ -106,7 +105,14 @@
           "name": "FlutterFlow Warnings"
         }
       ]
-    }
+    },
+    "uriHandlers": [
+      {
+        "protocol": "vscode",
+        "uriPattern": "^vscode://flutterflow\\.custom-code-editor.*",
+        "command": "flutterflow.handleUri"
+      }
+    ]
   },
   "scripts": {
     "build": "./node_modules/typescript/bin/tsc",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flutterflow-custom-code-editor",
   "displayName": "FlutterFlow: Custom Code Editor",
   "description": "Edit your FlutterFlow custom  widgets, action, and functions.",
-  "version": "1.2.1",
+  "version": "1.2.4",
   "publisher": "FlutterFlow",
   "repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "workspaceContains:pubspec.yaml",
+    "onUri"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
@@ -45,7 +48,12 @@
       {
         "command": "modifiedFiles.onClick",
         "title": "On select item"
+      },
+      {
+        "command": "flutterflow.handleUri",
+        "title": "Handle FlutterFlow URI"
       }
+
     ],
     "configuration": {
       "title": "FlutterFlow",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flutterflow-custom-code-editor",
   "displayName": "FlutterFlow: Custom Code Editor",
   "description": "Edit your FlutterFlow custom  widgets, action, and functions.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "publisher": "FlutterFlow",
   "repository": {
 		"type": "git",

--- a/src/actions/downloadCode.ts
+++ b/src/actions/downloadCode.ts
@@ -216,3 +216,27 @@ export async function downloadCodeWithPrompt(context: vscode.ExtensionContext, a
     });
     return { projectId, projectPath };
 };
+
+export async function verifyDownloadLocation(downloadPath: string): Promise<boolean> {
+    try {
+        // Check if path exists
+        if (!fs.existsSync(downloadPath)) {
+            return false;
+        }
+
+        // Check if it's a directory
+        const stats = await fs.promises.stat(downloadPath);
+        if (!stats.isDirectory()) {
+            return false;
+        }
+
+        // Check if we have write permissions
+        await fs.promises.access(downloadPath, fs.constants.W_OK);
+
+        return true;
+    } catch (error) {
+        console.error(`Error verifying download location: ${error}`);
+        return false;
+    }
+}
+

--- a/src/actions/downloadCode.ts
+++ b/src/actions/downloadCode.ts
@@ -89,7 +89,7 @@ export interface DownloadCodeArgs {
     downloadLocation?: string;
     branchName?: string;
     skipOpen?: boolean;
-    activeFile?: string;
+    initialFile?: string;
 }
 
 export async function downloadCodeWithPrompt(context: vscode.ExtensionContext, args: DownloadCodeArgs = {}): Promise<{ projectId: string, projectPath: string } | undefined> {
@@ -197,8 +197,8 @@ export async function downloadCodeWithPrompt(context: vscode.ExtensionContext, a
             }
 
             const updateManager = await downloadCode(projectPath, new FlutterFlowApiClient(token, getCurrentApiUrl(), projectId, branchName));
-            if (args.activeFile) {
-                await setInitialFile(projectPath, args.activeFile);
+            if (args.initialFile) {
+                await setInitialFile(projectPath, args.initialFile);
             }
 
             // context.globalState.update("downloadsPath", projectPath);

--- a/src/actions/downloadCode.ts
+++ b/src/actions/downloadCode.ts
@@ -1,6 +1,6 @@
 import { FlutterFlowApiClient } from "../api/FlutterFlowApiClient";
 import { insertCustomFunctionBoilerplate } from "../fileUtils/addBoilerplate";
-import { ffMetadataFromFile, ffMetadataToFile } from "../ffState/FlutterFlowMetadata";
+import { ffMetadataFromFile, ffMetadataToFile, setInitialFile } from "../ffState/FlutterFlowMetadata";
 import { deserializeUpdateManager, UpdateManager } from "../ffState/UpdateManager";
 import { getCurrentApiUrl } from "../api/environment";
 import * as path from "path";
@@ -89,9 +89,10 @@ export interface DownloadCodeArgs {
     downloadLocation?: string;
     branchName?: string;
     skipOpen?: boolean;
+    activeFile?: string;
 }
 
-export async function downloadCodeWithPrompt(context: vscode.ExtensionContext, args: DownloadCodeArgs = {}): Promise<{projectId: string, projectPath: string} | undefined> {
+export async function downloadCodeWithPrompt(context: vscode.ExtensionContext, args: DownloadCodeArgs = {}): Promise<{ projectId: string, projectPath: string } | undefined> {
     // Read project id from existing data and prompt user if not found.
     let projectId;
     if (args.projectId) {
@@ -196,6 +197,9 @@ export async function downloadCodeWithPrompt(context: vscode.ExtensionContext, a
             }
 
             const updateManager = await downloadCode(projectPath, new FlutterFlowApiClient(token, getCurrentApiUrl(), projectId, branchName));
+            if (args.activeFile) {
+                await setInitialFile(projectPath, args.activeFile);
+            }
 
             // context.globalState.update("downloadsPath", projectPath);
             // context.globalState.update("projectId", projectId);

--- a/src/actions/uriHandler.ts
+++ b/src/actions/uriHandler.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { getApiKey } from "../api/environment";
 import { downloadCodeWithPrompt, verifyDownloadLocation } from "./downloadCode";
-import { FF_METADATA_FILE_PATH, ffMetadataFromFile } from "../ffState/FlutterFlowMetadata";
+import { FF_METADATA_FILE_PATH, ffMetadataFromFile, setInitialFile } from "../ffState/FlutterFlowMetadata";
 
 export async function handleFlutterFlowUri(
     uri: vscode.Uri,
@@ -113,10 +113,11 @@ export async function handleFlutterFlowUri(
         }
 
         if (overwriteProjectChoice === 'Open Existing') {
+            const fullPath = path.join(projectDownloadPath, normalizedFileName);
+
             if (currentWorkspacePath === projectDownloadPath) {
                 // If project is already open in current workspace
                 if (fileName) {
-                    const fullPath = path.join(projectDownloadPath, normalizedFileName);
                     if (fs.existsSync(fullPath)) {
                         const doc = await vscode.workspace.openTextDocument(fullPath);
                         await vscode.window.showTextDocument(doc);
@@ -125,6 +126,7 @@ export async function handleFlutterFlowUri(
                 return false;
             } else {
                 // If project is not open in current workspace, open it
+                await setInitialFile(projectDownloadPath, normalizedFileName);
                 await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(projectDownloadPath));
                 return false;
             }

--- a/src/actions/uriHandler.ts
+++ b/src/actions/uriHandler.ts
@@ -12,9 +12,6 @@ export async function handleFlutterFlowUri(
 ): Promise<void> {
 
     console.log('opening project from URI ', uri);
-    if (1 > 0) {
-        return;
-    }
     // Parse all parameters from query string
     // Expected format: vscode://flutterflow.custom-code-editor?projectId={projectId}&branchName={branchId}&fileName={fileName}
     const params = new URLSearchParams(uri.query);

--- a/src/actions/uriHandler.ts
+++ b/src/actions/uriHandler.ts
@@ -98,7 +98,7 @@ export async function handleFlutterFlowUri(
                 'Project already exists locally. What would you like to do?',
                 { modal: true },
                 'Open Existing',
-                'Download Fresh Copy'
+                'Download From FlutterFlow'
             );
 
             if (choice === 'Open Existing') {

--- a/src/actions/uriHandler.ts
+++ b/src/actions/uriHandler.ts
@@ -50,10 +50,11 @@ export async function handleFlutterFlowUri(
             }
         }
 
-        // Check if download location is configured
-        const downloadLocation = vscode.workspace.getConfiguration('flutterflow').get<string>('downloadLocation');
+        // Get download path from settings
+        let downloadPath = vscode.workspace.getConfiguration("flutterflow").get<string>("downloadLocation") || "";
         //check if the download location is valid
-        if (!downloadLocation || !verifyDownloadLocation(downloadLocation)) {
+        const downloadLocationValid = await verifyDownloadLocation(downloadPath);
+        if (!downloadLocationValid) {
             const setLocation = await vscode.window.showInformationMessage(
                 'FlutterFlow download location not set. Would you like to set it now?',
                 { modal: true },
@@ -68,21 +69,13 @@ export async function handleFlutterFlowUri(
                 });
                 if (uris && uris[0]) {
                     await vscode.workspace.getConfiguration('flutterflow').update('downloadLocation', uris[0].fsPath, true);
+                    downloadPath = uris[0].fsPath;
                 } else {
                     return false;
                 }
             } else {
                 return false;
             }
-        }
-
-        // Get download path from settings
-        const downloadPath = vscode.workspace.getConfiguration("flutterflow").get<string>("downloadLocation") || "";
-
-        //check if the download path is a valid directory
-        if (!fs.existsSync(downloadPath)) {
-            vscode.window.showErrorMessage(`Invalid download path. ${downloadPath} does not exist.`);
-            return false;
         }
 
         // check if download path plus projectid exists

--- a/src/actions/uriHandler.ts
+++ b/src/actions/uriHandler.ts
@@ -113,16 +113,11 @@ export async function handleFlutterFlowUri(
         }
 
         if (overwriteProjectChoice === 'Open Existing') {
-            const fullPath = path.join(projectDownloadPath, normalizedFileName);
+            const fullPath = path.join(currentWorkspacePath || '', normalizedFileName);
 
-            if (currentWorkspacePath === projectDownloadPath) {
-                // If project is already open in current workspace
-                if (fileName) {
-                    if (fs.existsSync(fullPath)) {
-                        const doc = await vscode.workspace.openTextDocument(fullPath);
-                        await vscode.window.showTextDocument(doc);
-                    }
-                }
+            if (fs.existsSync(fullPath)) {
+                const doc = await vscode.workspace.openTextDocument(fullPath);
+                await vscode.window.showTextDocument(doc);
                 return false;
             } else {
                 // If project is not open in current workspace, open it

--- a/src/actions/uriHandler.ts
+++ b/src/actions/uriHandler.ts
@@ -101,9 +101,9 @@ export async function handleFlutterFlowUri(
         const currentBranchName = currentMetadata?.branch_name ? currentMetadata.branch_name : 'main';
         const uriBranchName = branchName ? branchName : 'main';
 
-        const downloadFromFlutterFlowPrompt = `Download From FlutterFlow ${currentMetadata != null ? ` (branch = ${uriBranchName})` : ''}`;
+        const downloadFromFlutterFlowPrompt = `Download From FlutterFlow (branch: ${uriBranchName})`;
         const overwriteProjectChoice = await vscode.window.showInformationMessage(
-            `Project ${projectId} already exists locally ${currentMetadata != null ? ` with branch = ${currentBranchName}` : ''}. What would you like to do?`,
+            `Project ${projectId} already exists locally (branch: ${currentBranchName})`,
             { modal: true },
             'Open Existing',
             downloadFromFlutterFlowPrompt

--- a/src/actions/uriHandler.ts
+++ b/src/actions/uriHandler.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 import { getApiKey } from "../api/environment";
-import { downloadCodeWithPrompt } from "./downloadCode";
+import { downloadCodeWithPrompt, verifyDownloadLocation } from "./downloadCode";
 import { FF_METADATA_FILE_PATH, ffMetadataFromFile } from "../ffState/FlutterFlowMetadata";
 
 export async function handleFlutterFlowUri(
@@ -52,7 +52,8 @@ export async function handleFlutterFlowUri(
 
         // Check if download location is configured
         const downloadLocation = vscode.workspace.getConfiguration('flutterflow').get<string>('downloadLocation');
-        if (!downloadLocation) {
+        //check if the download location is valid
+        if (!downloadLocation || !verifyDownloadLocation(downloadLocation)) {
             const setLocation = await vscode.window.showInformationMessage(
                 'FlutterFlow download location not set. Would you like to set it now?',
                 { modal: true },

--- a/src/actions/uriHandler.ts
+++ b/src/actions/uriHandler.ts
@@ -23,6 +23,8 @@ export async function handleFlutterFlowUri(
 
     const branchName = params.get('branchName') || 'main';
     const fileName = params.get('fileName') || '';
+    // Convert unix-style path separators to platform-specific separators
+    const normalizedFileName = fileName.split('/').join(path.sep);
 
     try {
         // Check if API key is configured
@@ -103,7 +105,7 @@ export async function handleFlutterFlowUri(
                 // If project is already open in current workspace
                 if (currentWorkspacePath === projectDownloadPath) {
                     if (fileName) {
-                        const fullPath = path.join(projectDownloadPath, fileName);
+                        const fullPath = path.join(projectDownloadPath, normalizedFileName);
                         if (fs.existsSync(fullPath)) {
                             const doc = await vscode.workspace.openTextDocument(fullPath);
                             await vscode.window.showTextDocument(doc);
@@ -115,7 +117,7 @@ export async function handleFlutterFlowUri(
                 }
                 // if the project is not open in the current workspace, open it
                 if (fileName) {
-                    await setInitialFile(projectDownloadPath, fileName);
+                    await setInitialFile(projectDownloadPath, normalizedFileName);
                 }
                 await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(projectDownloadPath));
                 return;
@@ -129,7 +131,7 @@ export async function handleFlutterFlowUri(
             projectId,
             branchName,
             downloadLocation: downloadPath,
-            initialFile: fileName
+            initialFile: normalizedFileName
         });
 
     } catch (err) {

--- a/src/actions/uriHandler.ts
+++ b/src/actions/uriHandler.ts
@@ -3,13 +3,12 @@ import * as path from "path";
 import * as fs from "fs";
 import { getApiKey } from "../api/environment";
 import { downloadCodeWithPrompt } from "./downloadCode";
-import { initializeCodeEditorWithVscode } from "./initializeCodeEditor";
-import { ffMetadataFromFile, setInitialFile } from "../ffState/FlutterFlowMetadata";
+import { FF_METADATA_FILE_PATH, ffMetadataFromFile } from "../ffState/FlutterFlowMetadata";
 
 export async function handleFlutterFlowUri(
     uri: vscode.Uri,
     context: vscode.ExtensionContext
-): Promise<void> {
+): Promise<boolean> {
 
     console.log('opening project from URI ', uri);
     // Parse all parameters from query string
@@ -18,7 +17,7 @@ export async function handleFlutterFlowUri(
     const projectId = params.get('projectId');
     if (!projectId) {
         vscode.window.showErrorMessage('Invalid FlutterFlow URI format: missing projectId');
-        return;
+        return false;
     }
 
     const branchName = params.get('branchName') || 'main';
@@ -44,10 +43,10 @@ export async function handleFlutterFlowUri(
                 if (key) {
                     await vscode.workspace.getConfiguration('flutterflow').update('userApiToken', key, true);
                 } else {
-                    return;
+                    return false;
                 }
             } else {
-                return;
+                return false;
             }
         }
 
@@ -69,10 +68,10 @@ export async function handleFlutterFlowUri(
                 if (uris && uris[0]) {
                     await vscode.workspace.getConfiguration('flutterflow').update('downloadLocation', uris[0].fsPath, true);
                 } else {
-                    return;
+                    return false;
                 }
             } else {
-                return;
+                return false;
             }
         }
 
@@ -82,7 +81,7 @@ export async function handleFlutterFlowUri(
         //check if the download path is a valid directory
         if (!fs.existsSync(downloadPath)) {
             vscode.window.showErrorMessage(`Invalid download path. ${downloadPath} does not exist.`);
-            return;
+            return false;
         }
 
         // check if download path plus projectid exists
@@ -90,79 +89,65 @@ export async function handleFlutterFlowUri(
         const projectDownloadPathExists = fs.existsSync(projectDownloadPath);
 
         const currentWorkspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        if (!projectDownloadPathExists) {
+            // Project doesn't exist, so we need to download it
+            await downloadCodeWithPrompt(context, {
+                projectId,
+                branchName,
+                downloadLocation: downloadPath,
+                initialFile: normalizedFileName
+            });
+            return true;
+        }
 
         // Project exists but isn't open
-        if (projectDownloadPathExists) {
-            // check metadata file
-            const metadataFilePath = path.join(projectDownloadPath, 'ff_metadata.json');
-            const metadataFileExists = fs.existsSync(metadataFilePath);
-            if (metadataFileExists) {
-                const metadata = ffMetadataFromFile(metadataFilePath);
-                if (metadata.branch_name !== branchName) {
-                    // currently downloaded branch is different than the branch name in the uri
-                    // so we need to download the project again
-                    const branchChoice = await vscode.window.showInformationMessage(
-                        'Local branch is different than the branch name in the uri. Would you like to overwrite the project directory with code from branch ' + branchName + '?',
-                        { modal: true },
-                        'Yes',
-                        'No'
-                    );
-                    if (branchChoice === 'Yes') {
-                        await downloadCodeWithPrompt(context, {
-                            projectId,
-                            branchName,
-                            downloadLocation: downloadPath,
-                            initialFile: normalizedFileName
-                        });
-                        return;
-                    } else {
-                        return;
-                    }
-                }
-            }
+        // check metadata file
+        const metadataFilePath = path.join(projectDownloadPath, FF_METADATA_FILE_PATH);
+        const currentMetadata = fs.existsSync(metadataFilePath) ? ffMetadataFromFile(metadataFilePath) : null;
+        const currentBranchName = currentMetadata?.branch_name ? currentMetadata.branch_name : 'main';
+        const uriBranchName = branchName ? branchName : 'main';
 
-            const choice = await vscode.window.showInformationMessage(
-                'Project already exists locally. What would you like to do?',
-                { modal: true },
-                'Open Existing',
-                'Download From FlutterFlow'
-            );
+        const downloadFromFlutterFlowPrompt = `Download From FlutterFlow ${currentMetadata != null ? ` (branch = ${uriBranchName})` : ''}`;
+        const overwriteProjectChoice = await vscode.window.showInformationMessage(
+            `Project ${projectId} already exists locally ${currentMetadata != null ? ` with branch = ${currentBranchName}` : ''}. What would you like to do?`,
+            { modal: true },
+            'Open Existing',
+            downloadFromFlutterFlowPrompt
+        );
+        if (overwriteProjectChoice === undefined) {
+            return false;
+        }
 
-            if (choice === 'Open Existing') {
+        if (overwriteProjectChoice === 'Open Existing') {
+            if (currentWorkspacePath === projectDownloadPath) {
                 // If project is already open in current workspace
-                if (currentWorkspacePath === projectDownloadPath) {
-                    if (fileName) {
-                        const fullPath = path.join(projectDownloadPath, normalizedFileName);
-                        if (fs.existsSync(fullPath)) {
-                            const doc = await vscode.workspace.openTextDocument(fullPath);
-                            await vscode.window.showTextDocument(doc);
-                        }
-                    }
-                    // Ensure editor is initialized
-                    await initializeCodeEditorWithVscode();
-                    return;
-                }
-                // if the project is not open in the current workspace, open it
                 if (fileName) {
-                    await setInitialFile(projectDownloadPath, normalizedFileName);
+                    const fullPath = path.join(projectDownloadPath, normalizedFileName);
+                    if (fs.existsSync(fullPath)) {
+                        const doc = await vscode.workspace.openTextDocument(fullPath);
+                        await vscode.window.showTextDocument(doc);
+                    }
                 }
+                return false;
+            } else {
+                // If project is not open in current workspace, open it
                 await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(projectDownloadPath));
-                return;
-            } else if (!choice) {
-                return; // User cancelled
+                return false;
             }
         }
 
-        // Download new copy
-        await downloadCodeWithPrompt(context, {
-            projectId,
-            branchName,
-            downloadLocation: downloadPath,
-            initialFile: normalizedFileName
-        });
-
+        if (overwriteProjectChoice === downloadFromFlutterFlowPrompt) {
+            await downloadCodeWithPrompt(context, {
+                projectId,
+                branchName: uriBranchName,
+                downloadLocation: downloadPath,
+                initialFile: normalizedFileName
+            });
+            return true;
+        }
     } catch (err) {
         console.error('handleUri error', err);
         vscode.window.showErrorMessage(`Error opening project from URL: ${err}`);
     }
+    return false;
 }

--- a/src/actions/uriHandler.ts
+++ b/src/actions/uriHandler.ts
@@ -89,19 +89,6 @@ export async function handleFlutterFlowUri(
 
         const currentWorkspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
 
-        // If project is already open in current workspace
-        if (currentWorkspacePath === projectDownloadPath) {
-            if (fileName) {
-                const fullPath = path.join(projectDownloadPath, fileName);
-                if (fs.existsSync(fullPath)) {
-                    const doc = await vscode.workspace.openTextDocument(fullPath);
-                    await vscode.window.showTextDocument(doc);
-                }
-            }
-            // Ensure editor is initialized
-            await initializeCodeEditorWithVscode();
-            return;
-        }
 
         // Project exists but isn't open
         if (projectDownloadPathExists) {
@@ -113,6 +100,20 @@ export async function handleFlutterFlowUri(
             );
 
             if (choice === 'Open Existing') {
+                // If project is already open in current workspace
+                if (currentWorkspacePath === projectDownloadPath) {
+                    if (fileName) {
+                        const fullPath = path.join(projectDownloadPath, fileName);
+                        if (fs.existsSync(fullPath)) {
+                            const doc = await vscode.workspace.openTextDocument(fullPath);
+                            await vscode.window.showTextDocument(doc);
+                        }
+                    }
+                    // Ensure editor is initialized
+                    await initializeCodeEditorWithVscode();
+                    return;
+                }
+                // if the project is not open in the current workspace, open it
                 if (fileName) {
                     await setInitialFile(projectDownloadPath, fileName);
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ import { pushToFF } from "./actions/pushToFF";
 import { performPullLatest } from "./actions/pullLatest";
 import { createEditStream, FFProjectState, ProjectState } from "./ffState/FFProjectState";
 import { FlutterFlowApiClient } from "./api/FlutterFlowApiClient";
-import { FlutterFlowMetadata, getInitialFile, setInitialFile } from "./ffState/FlutterFlowMetadata";
+import { FlutterFlowMetadata, getInitialFile } from "./ffState/FlutterFlowMetadata";
 import { handleFlutterFlowUri } from "./actions/uriHandler";
 
 // Pattern for watching custom code files
@@ -161,6 +161,7 @@ export function activate(context: vscode.ExtensionContext): vscode.ExtensionCont
   );
 
   // Modify the initialization sequence
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   checkRequiredFiles().then(async (isFlutterFlowProject) => {
     if (!isFlutterFlowProject) {
       return; // Exit if not a FlutterFlow project

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,5 @@
 // The module 'vscode' contains the VS Code extensibility API
 import * as vscode from "vscode";
-import * as path from "path";
-import * as fs from "fs";
 
 import { FileErrorProvider } from "./ui/FileErrorsPanel";
 import { getCurrentWebAppUrl, getApiKey, getCurrentApiUrl } from "./api/environment";
@@ -15,7 +13,7 @@ import { pushToFF } from "./actions/pushToFF";
 import { performPullLatest } from "./actions/pullLatest";
 import { createEditStream, FFProjectState, ProjectState } from "./ffState/FFProjectState";
 import { FlutterFlowApiClient } from "./api/FlutterFlowApiClient";
-import { FlutterFlowMetadata, getInitialFile, FF_METADATA_FILE_PATH } from "./ffState/FlutterFlowMetadata";
+import { FlutterFlowMetadata, FF_METADATA_FILE_PATH } from "./ffState/FlutterFlowMetadata";
 import { handleFlutterFlowUri } from "./actions/uriHandler";
 
 // Pattern for watching custom code files

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -317,7 +317,7 @@ export function activate(context: vscode.ExtensionContext): vscode.ExtensionCont
               });
             }
             // add a popup asking the user to confirm the download or if they just want to open the project directory
-            const confirmDownload = await vscode.window.showInformationMessage('Download and overwrite existing project? Or just open the project directory?', 'Download and overwrite', 'Open Project Directory');
+            const confirmDownload = await vscode.window.showInformationMessage('Download and overwrite existing project? Or just open the project directory that already exists?', { modal: true }, 'Download and overwrite', 'Open Existing Project');
             if (confirmDownload === 'Download and overwrite') {
               // Execute the download command with the parsed parameters
               // download the project
@@ -328,7 +328,7 @@ export function activate(context: vscode.ExtensionContext): vscode.ExtensionCont
                 initialFile: fileName
               });
 
-            } else {
+            } else if (confirmDownload === 'Open Existing Project') {
               const currentWorkspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
               if (currentWorkspacePath == projectDownloadPath) {
                 // if the project is already open, just open the initial file

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,8 +57,7 @@ async function checkRequiredFiles(): Promise<boolean> {
  */
 export function activate(context: vscode.ExtensionContext): vscode.ExtensionContext {
   // Register UI components
-  console.log('RYANDEBUG:activating extension');
-
+  console.log('activating FlutterFlow Custom Code Editor extension');
 
   context.subscriptions.push(ffStatusBar);
   vscode.window.registerTreeDataProvider("fileListTreeView", modifiedFileTreeProvider);
@@ -99,8 +98,6 @@ export function activate(context: vscode.ExtensionContext): vscode.ExtensionCont
     async (args: DownloadCodeArgs = {}) => {
       try {
         const currentWorkspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-        // RYANDEBUG test
-        args.initialFile = path.join('lib', 'custom_code', 'actions', 'index.dart');
         const projectConfigs = await downloadCodeWithPrompt(context, args);
         if (!projectConfigs) {
           return;
@@ -282,7 +279,7 @@ export function activate(context: vscode.ExtensionContext): vscode.ExtensionCont
   context.subscriptions.push(
     vscode.window.registerUriHandler({
       handleUri(uri: vscode.Uri): vscode.ProviderResult<void> {
-        console.log('RYANDEBUG:handleUri', uri);
+        console.log('opening project from URI ', uri);
         // Parse all parameters from query string
         // Expected format: vscode://flutterflow.custom-code-editor?projectId={projectId}&branchName={branchId}&fileName={fileName}
         const params = new URLSearchParams(uri.query);
@@ -295,9 +292,9 @@ export function activate(context: vscode.ExtensionContext): vscode.ExtensionCont
         const branchName = params.get('branchName') || 'main';
         const fileName = params.get('fileName') || '';
 
-        //get download path from settings
+        // Get download path from settings.
+        // TODO: should we assume this download path or prompt the user for it like the normal download flow?
         const downloadPath = vscode.workspace.getConfiguration("flutterflow").get<string>("downloadLocation") || "";
-        console.log('RYANDEBUG:downloadPath', downloadPath);
 
         //check if the download path is a valid directory
         if (!fs.existsSync(downloadPath)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { performPullLatest } from "./actions/pullLatest";
 import { createEditStream, FFProjectState, ProjectState } from "./ffState/FFProjectState";
 import { FlutterFlowApiClient } from "./api/FlutterFlowApiClient";
 import { FlutterFlowMetadata, getInitialFile, setInitialFile } from "./ffState/FlutterFlowMetadata";
+import { handleFlutterFlowUri } from "./actions/uriHandler";
 
 // Pattern for watching custom code files
 const kCustomFilePattern = `**/{pubspec.yaml,lib/custom_code/**,lib/flutter_flow/custom_functions.dart}`;
@@ -298,136 +299,12 @@ export function activate(context: vscode.ExtensionContext): vscode.ExtensionCont
   context.subscriptions.push(
     vscode.window.registerUriHandler({
       handleUri(uri: vscode.Uri): vscode.ProviderResult<void> {
-        console.log('opening project from URI ', uri);
-        // Parse all parameters from query string
-        // Expected format: vscode://flutterflow.custom-code-editor?projectId={projectId}&branchName={branchId}&fileName={fileName}
-        const params = new URLSearchParams(uri.query);
-        const projectId = params.get('projectId');
-        if (!projectId) {
-          vscode.window.showErrorMessage('Invalid FlutterFlow URI format: missing projectId');
-          return;
+        try {
+          return handleFlutterFlowUri(uri, context);
+        } catch (err) {
+          console.error('Error handling FlutterFlow URI:', err);
+          vscode.window.showErrorMessage(`Error handling FlutterFlow URI: ${err}`);
         }
-
-        const branchName = params.get('branchName') || 'main';
-        const fileName = params.get('fileName') || '';
-
-        const openProject = async () => {
-          try {
-            // Check if API key is configured
-            const apiKey = getApiKey();
-            if (!apiKey) {
-              const setApiKey = await vscode.window.showInformationMessage(
-                'FlutterFlow API key not found. Would you like to set it now?',
-                { modal: true },
-                'Yes', 'No'
-              );
-              if (setApiKey === 'Yes') {
-                const key = await vscode.window.showInputBox({
-                  prompt: 'Enter your FlutterFlow API key',
-                  password: true,
-                  ignoreFocusOut: true
-                });
-                if (key) {
-                  await vscode.workspace.getConfiguration('flutterflow').update('userApiToken', key, true);
-                } else {
-                  return;
-                }
-              } else {
-                return;
-              }
-            }
-
-            // Check if download location is configured
-            const downloadLocation = vscode.workspace.getConfiguration('flutterflow').get<string>('downloadLocation');
-            if (!downloadLocation) {
-              const setLocation = await vscode.window.showInformationMessage(
-                'FlutterFlow download location not set. Would you like to set it now?',
-                { modal: true },
-                'Yes', 'No',
-              );
-              if (setLocation === 'Yes') {
-                const uris = await vscode.window.showOpenDialog({
-                  canSelectFiles: false,
-                  canSelectFolders: true,
-                  canSelectMany: false,
-                  title: 'Select Download Location'
-                });
-                if (uris && uris[0]) {
-                  await vscode.workspace.getConfiguration('flutterflow').update('downloadLocation', uris[0].fsPath, true);
-                } else {
-                  return;
-                }
-              } else {
-                return;
-              }
-            }
-
-
-            // Get download path from settings.
-            // TODO: should we assume this download path or prompt the user for it like the normal download flow?
-            const downloadPath = vscode.workspace.getConfiguration("flutterflow").get<string>("downloadLocation") || "";
-
-            //check if the download path is a valid directory
-            if (!fs.existsSync(downloadPath)) {
-              vscode.window.showErrorMessage(`Invalid download path. ${downloadPath} does not exist.`);
-              return;
-            }
-            // check if download path plus projectid exists
-            const projectDownloadPath = path.join(downloadPath, projectId);
-            const projectDownloadPathExists = fs.existsSync(projectDownloadPath);
-
-            const currentWorkspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-
-            // If project is already open in current workspace
-            if (currentWorkspacePath === projectDownloadPath) {
-              if (fileName) {
-                const fullPath = path.join(projectDownloadPath, fileName);
-                if (fs.existsSync(fullPath)) {
-                  const doc = await vscode.workspace.openTextDocument(fullPath);
-                  await vscode.window.showTextDocument(doc);
-                }
-              }
-              // Ensure editor is initialized
-              await initCodeEditorFn();
-              return;
-            }
-
-            // Project exists but isn't open
-            if (projectDownloadPathExists) {
-              const choice = await vscode.window.showInformationMessage(
-                'Project already exists locally. What would you like to do?',
-                { modal: true },
-                'Open Existing',
-                'Download Fresh Copy'
-              );
-
-              if (choice === 'Open Existing') {
-                if (fileName) {
-                  await setInitialFile(projectDownloadPath, fileName);
-                }
-                await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(projectDownloadPath));
-                return;
-              } else if (!choice) {
-                return; // User cancelled
-              }
-            }
-
-            // Download new copy
-            await downloadCodeWithPrompt(context, {
-              projectId,
-              branchName,
-              downloadLocation: downloadPath,
-              initialFile: fileName
-            });
-
-          } catch (err) {
-            console.error('handleUri:openProject error', err);
-            vscode.window.showErrorMessage(`Error opening project from URL: ${err}`);
-          }
-        };
-
-        // unawaited promise to open the project
-        return openProject();
       }
     })
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -303,6 +303,7 @@ export function activate(context: vscode.ExtensionContext): vscode.ExtensionCont
         try {
           return handleFlutterFlowUri(uri, context).then((shouldReinitializeCurrentWorkspace) => {
             if (shouldReinitializeCurrentWorkspace) {
+              // eslint-disable-next-line @typescript-eslint/no-floating-promises
               initCodeEditorFn();
             }
           });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,18 +173,6 @@ export function activate(context: vscode.ExtensionContext): vscode.ExtensionCont
         throw new Error('No workspace folder found');
       }
 
-      // Then handle initial file opening first
-      const initialFile = await getInitialFile(projectPath);
-      if (initialFile) {
-        const fullPath = path.join(projectPath, initialFile);
-
-        // Verify file exists before attempting to open
-        if (fs.existsSync(fullPath)) {
-          const doc = await vscode.workspace.openTextDocument(fullPath);
-          await vscode.window.showTextDocument(doc);
-        }
-      }
-
       // Initialize the code editor
       await initCodeEditorFn();
     } catch (error) {

--- a/src/ffState/FlutterFlowMetadata.ts
+++ b/src/ffState/FlutterFlowMetadata.ts
@@ -12,6 +12,7 @@ export type FlutterFlowMetadata = {
     initial_file?: string;
 }
 
+export const FF_METADATA_FILE_PATH = path.join('.vscode', 'ff_metadata.json');
 
 export function ffMetadataFromFile(filePath: string): FlutterFlowMetadata {
     if (!fs.existsSync(filePath)) {
@@ -28,29 +29,17 @@ export async function ffMetadataToFile(filePath: string, metadata: FlutterFlowMe
     await fs.promises.writeFile(filePath, JSON.stringify(metadata, null, 2));
 }
 
-export async function writeFFMetadataFromContext(context: vscode.ExtensionContext): Promise<void> {
-    const metadata = {
-        project_id: context.globalState.get("projectId") as string,
-        branch_name: context.globalState.get("branchName") as string
-    };
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (workspaceFolders) {
-        const projectPath = workspaceFolders[0].uri.fsPath;
-        await ffMetadataToFile(path.join(projectPath, "ff_metadata.json"), metadata);
-    }
-}
-
 export async function setInitialFile(projectPath: string, activeFilePath: string) {
-    const metadata = ffMetadataFromFile(path.join(projectPath, "ff_metadata.json"));
+    const metadata = ffMetadataFromFile(path.join(projectPath, FF_METADATA_FILE_PATH));
     metadata.initial_file = activeFilePath;
-    await ffMetadataToFile(path.join(projectPath, "ff_metadata.json"), metadata);
+    await ffMetadataToFile(path.join(projectPath, FF_METADATA_FILE_PATH), metadata);
 }
 
 export async function getInitialFile(projectPath: string) {
-    const metadata = ffMetadataFromFile(path.join(projectPath, "ff_metadata.json"));
+    const metadata = ffMetadataFromFile(path.join(projectPath, FF_METADATA_FILE_PATH));
     const initialFile = metadata.initial_file;
     // clear the initial file
     metadata.initial_file = undefined;
-    await ffMetadataToFile(path.join(projectPath, "ff_metadata.json"), metadata);
+    await ffMetadataToFile(path.join(projectPath, FF_METADATA_FILE_PATH), metadata);
     return initialFile;
 }

--- a/src/ffState/FlutterFlowMetadata.ts
+++ b/src/ffState/FlutterFlowMetadata.ts
@@ -9,6 +9,7 @@ export type FlutterFlowMetadata = {
     };
     project_id: string;
     branch_name: string;
+    initial_file?: string;
 }
 
 
@@ -37,4 +38,19 @@ export async function writeFFMetadataFromContext(context: vscode.ExtensionContex
         const projectPath = workspaceFolders[0].uri.fsPath;
         await ffMetadataToFile(path.join(projectPath, "ff_metadata.json"), metadata);
     }
+}
+
+export async function setInitialFile(projectPath: string, activeFilePath: string) {
+    const metadata = ffMetadataFromFile(path.join(projectPath, "ff_metadata.json"));
+    metadata.initial_file = activeFilePath;
+    await ffMetadataToFile(path.join(projectPath, "ff_metadata.json"), metadata);
+}
+
+export async function getInitialFile(projectPath: string) {
+    const metadata = ffMetadataFromFile(path.join(projectPath, "ff_metadata.json"));
+    const initialFile = metadata.initial_file;
+    // clear the initial file
+    metadata.initial_file = undefined;
+    await ffMetadataToFile(path.join(projectPath, "ff_metadata.json"), metadata);
+    return initialFile;
 }

--- a/src/ffState/FlutterFlowMetadata.ts
+++ b/src/ffState/FlutterFlowMetadata.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as vscode from 'vscode';
 
 export type FlutterFlowMetadata = {
     flutterFlowFlutterVersion?: {

--- a/src/ffState/manage_flutter_version.ts
+++ b/src/ffState/manage_flutter_version.ts
@@ -53,7 +53,7 @@ export async function installFlutterIfNeeded(targetVersion: string, getVersionFn
         }
     } else {
         const downloadPromptResult = await vscode.window.showInformationMessage(
-            `Flutter SDK will be installed to ${downloadLocation}/ff_flutter_sdk Proceed?`,
+            `Flutter SDK will be installed to ${downloadLocation}${path.sep}ff_flutter_sdk Proceed?`,
             { modal: true },
             "Yes",
             "Select Different Download Location",


### PR DESCRIPTION
This change allows us to open specific custom code from links in the FlutterFlow frontend.

Part of making this happen smoothly required adding logic to support activating a coding session automatically.

So If a user who has the extension installed opens a folder where they have downloaded custom code, then the extension will automatically activate and track changes.
