### PR TITLE
[Bugfix] fix issue with downloading assets on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.1.9
+
+- Fix issue with downloading assets on Windows.
+
 ## 1.1.5
 
 - Added branch name info to status bar.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flutterflow-custom-code-editor",
   "displayName": "FlutterFlow: Custom Code Editor",
   "description": "Edit your FlutterFlow custom  widgets, action, and functions.",
-  "version": "1.1.6",
+  "version": "1.1.9",
   "publisher": "FlutterFlow",
   "repository": {
 		"type": "git",

--- a/src/api/exportCode.ts
+++ b/src/api/exportCode.ts
@@ -151,7 +151,7 @@ async function callExport(
 
 async function downloadAssets(destinationPath: string, assetDescriptions: AssetDescription[], unzipToParentFolder: boolean): Promise<void> {
     const downloadPromises = assetDescriptions.map(async (assetDescription) => {
-        let assetPath = assetDescription.path;
+        let assetPath = assetDescription.path.split('/').join(path.sep);
         if (!unzipToParentFolder) {
             assetPath = path.join(...path.parse(assetPath).dir.split(path.sep).slice(1), path.parse(assetPath).base);
         }


### PR DESCRIPTION
Due to an issue with path separators, downloading assets on Windows was causing issues and downloading all assets to the root of the project.

This fixes that issue.