### PR TITLE
Fix false "won't sync" warning on download

### DIFF
--- a/src/ffState/FFProjectState.ts
+++ b/src/ffState/FFProjectState.ts
@@ -80,6 +80,11 @@ export class FFProjectState {
 
     // Set the current state of the project
     public setState(state: ProjectState) {
+        // Entering EDITING means a fresh set of files just landed (initial download or a
+        // pull); restart the warm-up so the OS's replayed create events don't warn.
+        if (state === ProjectState.EDITING) {
+            this._updateManager.markEditingStarted();
+        }
         this._state = state;
     }
 

--- a/src/ffState/UpdateManager.ts
+++ b/src/ffState/UpdateManager.ts
@@ -64,6 +64,9 @@ export class UpdateManager {
   // Relative keys touched by a just-handled rename, with their expiry time. Used to
   // ignore the watcher's delete(old)/create(new) events that a rename produces.
   private _recentlyRenamed: Map<string, number> = new Map();
+  // When the current editing session started. Used to ignore the burst of watcher
+  // "create" events the OS replays for the just-downloaded project files.
+  private _editingStartedAt: number = Date.now();
   // Root path of the project
   private _rootPath: string;
 
@@ -136,6 +139,30 @@ export class UpdateManager {
   // Window during which the watcher events produced by a rename are ignored.
   private static readonly kRenameGuardMs = 3000;
 
+  // Window after an editing session starts during which the "won't sync" warning is
+  // suppressed, to skip the OS's replayed create events for the downloaded files.
+  private static readonly kEditingWarmupMs = 5000;
+
+  /** Marks the start of an editing session (resets the warm-up window). */
+  public markEditingStarted(): void {
+    this._editingStartedAt = Date.now();
+  }
+
+  private inEditingWarmup(): boolean {
+    return Date.now() - this._editingStartedAt < UpdateManager.kEditingWarmupMs;
+  }
+
+  // True when the file was already on disk before this session started — i.e. a
+  // downloaded/pulled file whose create event the OS is replaying, not one the user
+  // just authored. Robust even if the replay arrives after the warm-up window.
+  private existedBeforeSession(filePath: string): boolean {
+    try {
+      return fs.statSync(filePath).mtimeMs <= this._editingStartedAt;
+    } catch {
+      return false;
+    }
+  }
+
   private markRecentlyRenamed(relKey: string): void {
     this._recentlyRenamed.set(relKey, Date.now() + UpdateManager.kRenameGuardMs);
   }
@@ -169,6 +196,8 @@ export class UpdateManager {
       relKey.startsWith('lib/') &&
       relKey.endsWith('.dart') &&
       path.posix.basename(relKey) !== 'index.dart' &&
+      !this.inEditingWarmup() &&
+      !this.existedBeforeSession(filePath) &&
       !warnedAboutUnclassifiedFile
     ) {
       warnedAboutUnclassifiedFile = true;


### PR DESCRIPTION
Right after downloading a folder-organized project, users saw a spurious warning like *`"custom_functions.dart" won't sync to FlutterFlow`*.

**Cause:** when the file watcher is created on the freshly downloaded folder, the OS (macOS FSEvents) replays `create` events for the project files just written during the download. Those 'add' events tripped the one-time "won't sync" warning on whichever generated file landed first (here, the `custom_functions.dart` export shim — next time it could be any generated file).

**Fix:** suppress that warning for a short warm-up window after an editing session starts (set on every transition to `EDITING` — initial download and each pull). The warning now only fires for files the user actually creates while editing; classification and sync behavior are unchanged.

Follow-up to #21. Tests: tsc + eslint clean, jest 35/35, harness 27/27.

---

**Hardening:** the fix uses two complementary guards so the warning is robust across project sizes:
- a short warm-up window after the session starts, and
- an mtime check — a file whose mtime predates the session was already on disk (a replayed download/pull), so it's never treated as a user-authored file regardless of when the OS delivers its create event.

The warning now only fires for files genuinely created while editing.
