### PR TITLE
Add build/publish tooling (.vscodeignore + Makefile)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ src/.DS_Store
 # build directory
 dist/
 out/
+build/
 
 # vscode test files
 .vscode-test/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,23 @@
+# The extension ships as a single esbuild bundle (dist/extension.js), so source,
+# dependencies, tests, and tooling don't belong in the published .vsix.
+.vscode/**
+.vscode-test/**
+.vscode-test.js
+.github/**
+src/**
+testdata/**
+coverage/**
+node_modules/**
+out/**
+dist/test/**
+**/*.map
+**/*.ts
+**/tsconfig*.json
+eslint.config.mjs
+jest.config.js
+esbuild.js
+Makefile
+DEV_GUIDE.md
+.gitignore
+.fvmrc
+**/*.vsix

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,20 @@
 # FlutterFlow VS Code Extension — build & publish helpers.
 #
-# Publishing targets the `FlutterFlow` Marketplace publisher and needs a
-# Personal Access Token (Azure DevOps, scope: Marketplace > Manage). Provide it
-# once with `make login`, or export VSCE_PAT in the environment.
-#
-# Always publish from a clean, merged `main` — the published artifact should
+# Always build from a clean, merged `main` — the published artifact should
 # match the repo's source of truth.
+#
+# Two ways to publish (both require membership in the `FlutterFlow` Marketplace
+# publisher: https://marketplace.visualstudio.com/manage/publishers/flutterflow):
+#
+# 1. Manual web upload (no token needed):
+#      - `make package`  (writes build/*.vsix)
+#      - Open https://marketplace.visualstudio.com/manage/publishers/flutterflow
+#      - Extensions tab -> "FlutterFlow: Custom Code Editor" row -> `...` -> Update
+#      - Drag in build/*.vsix and confirm. Version is read from package.json.
+#
+# 2. CLI (`make publish`): needs a Personal Access Token (Azure DevOps, scope
+#    Marketplace > Manage, organization "All accessible organizations").
+#    Provide it once with `make login`, or export VSCE_PAT in the environment.
 
 VSCE ?= npx --yes @vscode/vsce
 
@@ -24,7 +33,7 @@ test:
 	npm test
 	npx jest
 
-## package: produce a versioned .vsix in build/ (runs vscode:prepublish automatically)
+## package: build a versioned .vsix into build/ (drag into the web portal, or run `make publish`)
 package:
 	@mkdir -p build
 	$(VSCE) package --out build/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+# FlutterFlow VS Code Extension — build & publish helpers.
+#
+# Publishing targets the `FlutterFlow` Marketplace publisher and needs a
+# Personal Access Token (Azure DevOps, scope: Marketplace > Manage). Provide it
+# once with `make login`, or export VSCE_PAT in the environment.
+#
+# Always publish from a clean, merged `main` — the published artifact should
+# match the repo's source of truth.
+
+VSCE ?= npx --yes @vscode/vsce
+
+.PHONY: install build test package login publish clean
+
+## install: clean install of dependencies
+install:
+	npm ci
+
+## build: production bundle (type-check + lint + minified esbuild)
+build:
+	npm run package
+
+## test: run the VS Code integration harness and the jest unit tests
+test:
+	npm test
+	npx jest
+
+## package: produce a versioned .vsix in build/ (runs vscode:prepublish automatically)
+package:
+	@mkdir -p build
+	$(VSCE) package --out build/
+
+## login: authenticate the FlutterFlow publisher (interactive PAT prompt)
+login:
+	$(VSCE) login FlutterFlow
+
+## publish: publish the current package.json version to the Marketplace
+publish:
+	$(VSCE) publish
+
+## clean: remove build output and packaged artifacts
+clean:
+	rm -rf dist build


### PR DESCRIPTION
Deploy tooling for the extension, split out from the 1.3.0 changes.

### .vscodeignore
The extension ships as a single esbuild bundle (`dist/extension.js`), but with no `.vscodeignore` the packaged `.vsix` also bundled `node_modules/`, `src/`, `testdata/`, and `coverage/` — ~7 MB / 1300+ files. This ignores everything that isn't needed at runtime, so the package is ~242 KB / 8 files (bundle + `package.json` + `assets/` + readme/changelog/license).

### Makefile
Convenience targets so releasing isn't ad-hoc `npx vsce` invocations:
- `make build` — production bundle (type-check + lint + minified esbuild)
- `make test` — VS Code harness + jest
- `make package` — versioned `.vsix` written into `build/` (runs `vscode:prepublish`)
- `make login` / `make publish` — Marketplace auth + publish (PAT via `make login` or `VSCE_PAT`)

### .gitignore
- Ignore `build/` (the new package output dir).

No version bump — tooling-only, doesn't change the shipped extension.